### PR TITLE
Fixed disk full of error message in Create volume

### DIFF
--- a/cinder/tests/unit/test_sheepdog.py
+++ b/cinder/tests/unit/test_sheepdog.py
@@ -123,7 +123,7 @@ Failed to create VDI %(volname)s: VDI exists already
 
     DOG_VDI_CREATE_FAILD_TO_WRITE_OBJECT = """\
 Failed to create VDI %(volname)s: Failed to write to requested VDI
-"""
+"""""
 
     DOG_VDI_DELETE_VDI_NOT_EXISTS = """\
 Failed to open VDI vdiname (snapshot id: 0 snapshot tag: ): No VDI found
@@ -285,8 +285,7 @@ class SheepdogClientTestCase(test.TestCase):
         expected_msg = self.test_data.sheepdog_cmd_error(
             cmd=cmd, exit_code=exit_code, stdout=stdout, stderr=stderr)
         expected_err = _LE('Failed to connect sheep daemon. '
-                           'addr: %(addr)s, port: %(port)s') % \
-            {'addr': SHEEP_ADDR, 'port': SHEEP_PORT}
+                           'addr: %(addr)s, port: %(port)s')
         with mock.patch.object(self.client, '_run_dog') as fake_execute:
             fake_execute.side_effect = exception.SheepdogCmdError(
                 cmd=cmd, exit_code=exit_code,
@@ -296,7 +295,9 @@ class SheepdogClientTestCase(test.TestCase):
                 ex = self.assertRaises(exception.SheepdogCmdError,
                                        self.client.create,
                                        self.test_data.TEST_VOLUME)
-                fake_logger.error.assert_called_with(expected_err)
+                fake_logger.error.assert_called_with(expected_err,
+                                                     {'addr': SHEEP_ADDR,
+                                                      'port': SHEEP_PORT})
                 self.assertEqual(expected_msg, ex.msg)
 
     def test_create_failed_vdi_already_exist(self):
@@ -309,8 +310,7 @@ class SheepdogClientTestCase(test.TestCase):
             {'volname': self.test_data.TEST_VOLUME['name']}
         expected_msg = self.test_data.sheepdog_cmd_error(
             cmd=cmd, exit_code=exit_code, stdout=stdout, stderr=stderr)
-        expected_err = _LE('Volume already exists. %s') % \
-            self.test_data.TEST_VOLUME['name']
+        expected_err = _LE('Volume already exists. %s')
         with mock.patch.object(self.client, '_run_dog') as fake_execute:
             fake_execute.side_effect = exception.SheepdogCmdError(
                 cmd=cmd, exit_code=exit_code,
@@ -320,7 +320,9 @@ class SheepdogClientTestCase(test.TestCase):
                 ex = self.assertRaises(exception.SheepdogCmdError,
                                        self.client.create,
                                        self.test_data.TEST_VOLUME)
-                fake_logger.error.assert_called_with(expected_err)
+                fake_logger.error.assert_called_with(expected_err,
+                                                     self.test_data.
+                                                     TEST_VOLUME['name'])
                 self.assertEqual(expected_msg, ex.msg)
 
     def test_create_failed_to_write_object(self):
@@ -333,8 +335,7 @@ class SheepdogClientTestCase(test.TestCase):
             {'volname': self.test_data.TEST_VOLUME['name']}
         expected_msg = self.test_data.sheepdog_cmd_error(
             cmd=cmd, exit_code=exit_code, stdout=stdout, stderr=stderr)
-        expected_err = _LE('Failed to write object to any sheep node. %s') % \
-            self.test_data.TEST_VOLUME['name']
+        expected_err = _LE('Failed to write object to any sheep node. %s')
         with mock.patch.object(self.client, '_run_dog') as fake_execute:
             fake_execute.side_effect = exception.SheepdogCmdError(
                 cmd=cmd, exit_code=exit_code,
@@ -344,7 +345,9 @@ class SheepdogClientTestCase(test.TestCase):
                 ex = self.assertRaises(exception.SheepdogCmdError,
                                        self.client.create,
                                        self.test_data.TEST_VOLUME)
-                fake_logger.error.assert_called_with(expected_err)
+                fake_logger.error.assert_called_with(expected_err,
+                                                     self.test_data.
+                                                     TEST_VOLUME['name'])
                 self.assertEqual(expected_msg, ex.msg)
 
     def test_create_failed_unknown(self):
@@ -356,8 +359,7 @@ class SheepdogClientTestCase(test.TestCase):
         stderr = 'stderr_dummy'
         expected_msg = self.test_data.sheepdog_cmd_error(
             cmd=cmd, exit_code=exit_code, stdout=stdout, stderr=stderr)
-        expected_err = _LE('Failed to create volume. %s') % \
-            self.test_data.TEST_VOLUME['name']
+        expected_err = _LE('Failed to create volume. %s')
         with mock.patch.object(self.client, '_run_dog') as fake_execute:
             fake_execute.side_effect = exception.SheepdogCmdError(
                 cmd=cmd, exit_code=exit_code,
@@ -367,7 +369,9 @@ class SheepdogClientTestCase(test.TestCase):
                 ex = self.assertRaises(exception.SheepdogCmdError,
                                        self.client.create,
                                        self.test_data.TEST_VOLUME)
-                fake_logger.error.assert_called_with(expected_err)
+                fake_logger.error.assert_called_with(expected_err,
+                                                     self.test_data.
+                                                     TEST_VOLUME['name'])
                 self.assertEqual(expected_msg, ex.msg)
 
     # test for delete method

--- a/cinder/tests/unit/test_sheepdog.py
+++ b/cinder/tests/unit/test_sheepdog.py
@@ -121,10 +121,6 @@ Epoch Time           Version [Host:Port:V-Nodes,,,]
 Failed to create VDI %(volname)s: VDI exists already
 """
 
-    DOG_VDI_CREATE_FAILD_TO_WRITE_OBJECT = """\
-Failed to create VDI %(volname)s: Failed to write to requested VDI
-"""""
-
     DOG_VDI_DELETE_VDI_NOT_EXISTS = """\
 Failed to open VDI vdiname (snapshot id: 0 snapshot tag: ): No VDI found
 """
@@ -311,31 +307,6 @@ class SheepdogClientTestCase(test.TestCase):
         expected_msg = self.test_data.sheepdog_cmd_error(
             cmd=cmd, exit_code=exit_code, stdout=stdout, stderr=stderr)
         expected_err = _LE('Volume already exists. %s')
-        with mock.patch.object(self.client, '_run_dog') as fake_execute:
-            fake_execute.side_effect = exception.SheepdogCmdError(
-                cmd=cmd, exit_code=exit_code,
-                stdout=stdout.replace('\n', '\\n'),
-                stderr=stderr.replace('\n', '\\n'))
-            with mock.patch.object(sheepdog, 'LOG') as fake_logger:
-                ex = self.assertRaises(exception.SheepdogCmdError,
-                                       self.client.create,
-                                       self.test_data.TEST_VOLUME)
-                fake_logger.error.assert_called_with(expected_err,
-                                                     self.test_data.
-                                                     TEST_VOLUME['name'])
-                self.assertEqual(expected_msg, ex.msg)
-
-    def test_create_failed_to_write_object(self):
-        cmd = self.test_data.cmd_dog_vdi_create(
-            self.test_data.TEST_VOLUME['name'],
-            self.test_data.TEST_VOLUME['size'])
-        exit_code = 1
-        stdout = ''
-        stderr = self.test_data.DOG_VDI_CREATE_FAILD_TO_WRITE_OBJECT % \
-            {'volname': self.test_data.TEST_VOLUME['name']}
-        expected_msg = self.test_data.sheepdog_cmd_error(
-            cmd=cmd, exit_code=exit_code, stdout=stdout, stderr=stderr)
-        expected_err = _LE('Failed to write object to any sheep node. %s')
         with mock.patch.object(self.client, '_run_dog') as fake_execute:
             fake_execute.side_effect = exception.SheepdogCmdError(
                 cmd=cmd, exit_code=exit_code,

--- a/cinder/tests/unit/test_sheepdog.py
+++ b/cinder/tests/unit/test_sheepdog.py
@@ -297,13 +297,14 @@ class SheepdogClientTestCase(test.TestCase):
                 self.assertEqual(expected_msg, ex.msg)
 
     def test_create_failed_vdi_already_exist(self):
+        volname = self.test_data.TEST_VOLUME['name']
         cmd = self.test_data.cmd_dog_vdi_create(
-            self.test_data.TEST_VOLUME['name'],
+            volname,
             self.test_data.TEST_VOLUME['size'])
         exit_code = 1
         stdout = ''
         stderr = self.test_data.DOG_VDI_CREATE_VDI_EXISTS_ALREADY % \
-            {'volname': self.test_data.TEST_VOLUME['name']}
+            {'volname': volname}
         expected_msg = self.test_data.sheepdog_cmd_error(
             cmd=cmd, exit_code=exit_code, stdout=stdout, stderr=stderr)
         expected_err = _LE('Volume already exists. %s')
@@ -316,14 +317,13 @@ class SheepdogClientTestCase(test.TestCase):
                 ex = self.assertRaises(exception.SheepdogCmdError,
                                        self.client.create,
                                        self.test_data.TEST_VOLUME)
-                fake_logger.error.assert_called_with(expected_err,
-                                                     self.test_data.
-                                                     TEST_VOLUME['name'])
+                fake_logger.error.assert_called_with(expected_err, volname)
                 self.assertEqual(expected_msg, ex.msg)
 
     def test_create_failed_unknown(self):
+        volname = self.test_data.TEST_VOLUME['name']
         cmd = self.test_data.cmd_dog_vdi_create(
-            self.test_data.TEST_VOLUME['name'],
+            volname,
             self.test_data.TEST_VOLUME['size'])
         exit_code = 1
         stdout = 'stdout_dummy'
@@ -340,9 +340,7 @@ class SheepdogClientTestCase(test.TestCase):
                 ex = self.assertRaises(exception.SheepdogCmdError,
                                        self.client.create,
                                        self.test_data.TEST_VOLUME)
-                fake_logger.error.assert_called_with(expected_err,
-                                                     self.test_data.
-                                                     TEST_VOLUME['name'])
+                fake_logger.error.assert_called_with(expected_err, volname)
                 self.assertEqual(expected_msg, ex.msg)
 
     # test for delete method

--- a/cinder/tests/unit/test_sheepdog.py
+++ b/cinder/tests/unit/test_sheepdog.py
@@ -121,8 +121,8 @@ Epoch Time           Version [Host:Port:V-Nodes,,,]
 Failed to create VDI %(volname)s: VDI exists already
 """
 
-    DOG_VDI_CREATE_NO_SPACE_FOR_NEW_OBJ = """\
-fail 8011111100000000, Server has no space for new objects
+    DOG_VDI_CREATE_FAILD_TO_WRITE_OBJECT = """\
+Failed to create VDI %(volname)s: Failed to write to requested VDI
 """
 
     DOG_VDI_DELETE_VDI_NOT_EXISTS = """\
@@ -323,17 +323,18 @@ class SheepdogClientTestCase(test.TestCase):
                 fake_logger.error.assert_called_with(expected_err)
                 self.assertEqual(expected_msg, ex.msg)
 
-    def test_create_failed_diskfull(self):
+    def test_create_failed_to_write_object(self):
         cmd = self.test_data.cmd_dog_vdi_create(
             self.test_data.TEST_VOLUME['name'],
             self.test_data.TEST_VOLUME['size'])
         exit_code = 1
         stdout = ''
-        stderr = self.test_data.DOG_VDI_CREATE_NO_SPACE_FOR_NEW_OBJ
+        stderr = self.test_data.DOG_VDI_CREATE_FAILD_TO_WRITE_OBJECT % \
+            {'volname': self.test_data.TEST_VOLUME['name']}
         expected_msg = self.test_data.sheepdog_cmd_error(
             cmd=cmd, exit_code=exit_code, stdout=stdout, stderr=stderr)
-        expected_err = _LE('Failed to create volume for diskfull occurs '
-                           'in datastore.')
+        expected_err = _LE('Failed to write object to any sheep node. %s') % \
+            self.test_data.TEST_VOLUME['name']
         with mock.patch.object(self.client, '_run_dog') as fake_execute:
             fake_execute.side_effect = exception.SheepdogCmdError(
                 cmd=cmd, exit_code=exit_code,

--- a/cinder/volume/drivers/sheepdog.py
+++ b/cinder/volume/drivers/sheepdog.py
@@ -64,7 +64,7 @@ class SheepdogClient(object):
     DOG_RESP_CLUSTER_WAITING = ('Cluster status: '
                                 'Waiting for other nodes to join cluster')
     DOG_RESP_VDI_EXISTS_ALREADY = ': VDI exists already\\n'
-    DOG_RESP_NO_SPACE_FOR_NEW_OBJ = 'Server has no space for new objects\\n'
+    DOG_RESP_FAILD_TO_WRITE_OBJECT = ': Failed to write to requested VDI\\n'
     DOG_RESP_VDI_NOT_FOUND = ': No VDI found\n'
 
     def __init__(self, addr, port):
@@ -130,9 +130,9 @@ class SheepdogClient(object):
                 elif stderr.endswith(self.DOG_RESP_VDI_EXISTS_ALREADY):
                     LOG.error(_LE('Volume already exists. %(volname)s') %
                               {'volname': volume['name']})
-                elif stderr.endswith(self.DOG_RESP_NO_SPACE_FOR_NEW_OBJ):
-                    LOG.error(_LE('Failed to create volume for diskfull occurs'
-                              ' in datastore.'))
+                elif stderr.endswith(self.DOG_RESP_FAILD_TO_WRITE_OBJECT):
+                    LOG.error(_LE('Failed to write object to any sheep node. '
+                              '%s') % volume['name'])
                 else:
                     LOG.error(_LE('Failed to create volume. %s') %
                               volume['name'])

--- a/cinder/volume/drivers/sheepdog.py
+++ b/cinder/volume/drivers/sheepdog.py
@@ -64,7 +64,6 @@ class SheepdogClient(object):
     DOG_RESP_CLUSTER_WAITING = ('Cluster status: '
                                 'Waiting for other nodes to join cluster')
     DOG_RESP_VDI_EXISTS_ALREADY = ': VDI exists already\\n'
-    DOG_RESP_FAILD_TO_WRITE_OBJECT = ': Failed to write to requested VDI\\n'
     DOG_RESP_VDI_NOT_FOUND = ': No VDI found\n'
 
     def __init__(self, addr, port):
@@ -129,9 +128,6 @@ class SheepdogClient(object):
                               {'addr': self.addr, 'port': self.port})
                 elif stderr.endswith(self.DOG_RESP_VDI_EXISTS_ALREADY):
                     LOG.error(_LE('Volume already exists. %s'), volume['name'])
-                elif stderr.endswith(self.DOG_RESP_FAILD_TO_WRITE_OBJECT):
-                    LOG.error(_LE('Failed to write object to any sheep node. '
-                              '%s'), volume['name'])
                 else:
                     LOG.error(_LE('Failed to create volume. %s'),
                               volume['name'])

--- a/cinder/volume/drivers/sheepdog.py
+++ b/cinder/volume/drivers/sheepdog.py
@@ -124,17 +124,16 @@ class SheepdogClient(object):
             stderr = e.kwargs['stderr']
             with excutils.save_and_reraise_exception():
                 if stderr.startswith(self.DOG_RESP_CONNECTION_ERROR):
-                    LOG.error(_LE('Failed to connect sheep daemon. '
-                              'addr: %(addr)s, port: %(port)s') %
+                    LOG.error(_LE("Failed to connect sheep daemon. "
+                              "addr: %(addr)s, port: %(port)s"),
                               {'addr': self.addr, 'port': self.port})
                 elif stderr.endswith(self.DOG_RESP_VDI_EXISTS_ALREADY):
-                    LOG.error(_LE('Volume already exists. %(volname)s') %
-                              {'volname': volume['name']})
+                    LOG.error(_LE('Volume already exists. %s'), volume['name'])
                 elif stderr.endswith(self.DOG_RESP_FAILD_TO_WRITE_OBJECT):
                     LOG.error(_LE('Failed to write object to any sheep node. '
-                              '%s') % volume['name'])
+                              '%s'), volume['name'])
                 else:
-                    LOG.error(_LE('Failed to create volume. %s') %
+                    LOG.error(_LE('Failed to create volume. %s'),
                               volume['name'])
 
     def delete(self, volume):


### PR DESCRIPTION
ディスクフル時にsheepで出力される下記例のメッセージファイルはデータオブジェクト書き込み時にディスクフルが発生した場合のみ出力されるメッセージとなっておりました。
　例1：fail 8011111100000000, Server has no space for new objects
ディスクフルを含めてinodeファイル書き込み（sd_write_object）時にSD_RES_SUCCESS以外が返却された場合には以下のメッセージが出力されます。
　例2：Failed to create VDI testvdi: Failed to write to requested VDI
今回CinderではPreallocateオプションなしでのcreateを行う想定ですので、例1のメッセージは期待されないため、例2のメッセージをハンドルする様に変更しました。ディスクフル以外の契機でも書き込みに失敗した場合は出力されるログのため、ディスクフルの判定は出来なくなりました。

追記：
Failed to write to requested VDIは特定のエラーケースを特定出来るエラーメッセージではないため、エラー判定のelseにてknown errorとして判定する整理となった。そのため、対象のエラーハンドリングの処理を削除。
